### PR TITLE
Load npy files asynchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ yarn add npyjs
 # npm i npyjs
 ```
 
+## Import 
+
+```javascript
+import npyjs from "npyjs";
+```
+
+
 ## Usage
 
 -   Create a new npyjs object.
@@ -25,7 +32,7 @@ yarn add npyjs
 let n = new npyjs();
 ```
 
--   This object can now be used load .npy files. Arrays are returned via a JavaScript callback, so usage looks like this:
+-   This object can now be used load .npy files. Arrays can be returned via a JavaScript callback, so usage looks like this:
 
 ```javascript
 n.load("my-array.npy", (array, shape) => {
@@ -37,12 +44,26 @@ n.load("my-array.npy", (array, shape) => {
 });
 ```
 
-You can also use this library promise-style:
+-   You can also use this library promise-style using either .then or async await:
 
 ```javascript
 n.load("test.npy").then((res) => {
     // res has { data, shape, dtype } members.
 });
+```
+
+```javascript
+const npyArray = await n.load("test.npy");
+```
+
+## Accessing multidimensional array elements
+
+-   You can conveniently access multidimensional array elements using the 'ndarray' library:
+
+```javascript
+import ndarray from "ndarray";
+const npyArray = ndarray(data, shape);
+npyArray.get(10, 15)
 ```
 
 Unless otherwise specified, all code inside of this repository is covered under the license in [LICENSE](LICENSE).

--- a/index.js
+++ b/index.js
@@ -101,6 +101,20 @@ class npyjs {
         };
     }
 
+    async readFileAsync(file) {
+		return new Promise((resolve, reject) => {
+			let reader = new FileReader();
+
+			reader.onload = () => {
+				resolve(reader.result);
+			};
+
+			reader.onerror = reject;
+
+			reader.readAsArrayBuffer(file);
+		});
+	}
+
     async load(filename, callback) {
         /*
         Loads an array from a stream of bytes.
@@ -110,16 +124,14 @@ class npyjs {
             if (fh.ok) {
                 return fh.blob().then(i => {
                     var content = i;
-                    var reader = new FileReader();
-                    reader.addEventListener("loadend", function () {
-                        var text = reader.result;
-                        var res = self.parse(text);
+                    return self.readFileAsync(content).then((res) => {
+                        var result = self.parse(res);
                         if (callback) {
-                            return callback(res);
+                            return callback(result);
                         }
-                        return res;
+                        console.log(result);
+                        return result;
                     });
-                    reader.readAsArrayBuffer(content);
                 }).catch(err => console.error(err));
             }
         }).catch(err => console.error(err));

--- a/index.js
+++ b/index.js
@@ -80,8 +80,8 @@ class npyjs {
         );
         var header = JSON.parse(
             hcontents
+                .toLowerCase() // True -> true
                 .replace(/'/g, '"')
-                .replace("False", "false")
                 .replace("(", "[")
                 .replace(/,*\),*/g, "]")
         );

--- a/index.js
+++ b/index.js
@@ -97,7 +97,8 @@ class npyjs {
         return {
             dtype: dtype.name,
             data: nums,
-            shape
+            shape,
+            fortranOrder: header.fortran_order
         };
     }
 

--- a/index.js
+++ b/index.js
@@ -102,18 +102,18 @@ class npyjs {
     }
 
     async readFileAsync(file) {
-		return new Promise((resolve, reject) => {
-			let reader = new FileReader();
+        return new Promise((resolve, reject) => {
+            let reader = new FileReader();
 
-			reader.onload = () => {
-				resolve(reader.result);
-			};
+            reader.onload = () => {
+                resolve(reader.result);
+            };
 
-			reader.onerror = reject;
+            reader.onerror = reject;
 
-			reader.readAsArrayBuffer(file);
-		});
-	}
+            reader.readAsArrayBuffer(file);
+        });
+    }
 
     async load(filename, callback) {
         /*
@@ -129,7 +129,6 @@ class npyjs {
                         if (callback) {
                             return callback(result);
                         }
-                        console.log(result);
                         return result;
                     });
                 }).catch(err => console.error(err));


### PR DESCRIPTION
 - Asynchronous loading wasn't working before. So I've converted the fileReader() to allow asynchronous loading,
 - Added support for loading in npy files for both C-contiguous and Fortran-contiguous array orders,
 - Updated readme