### PR TITLE
use fetch arrayBuffer() if present

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -1,29 +1,33 @@
 import assert from "assert";
-import fs from "fs";
+import {promises as fs} from "fs";
 import path from "path";
+import http from "http";
 import N from "../index.js";
 
-
 describe("npyjs parser", function () {
+    it("should correctly parse npy files", async function () {
+        const server = http.createServer(async function (req, res) {
+            const fpath = path.resolve(req.url.slice(1));
+            const data = await fs.readFile(fpath);
+            res.writeHead(200);
+            res.end(data);
+        });
+        server.listen();
+        const {port} = server.address()
 
-    it("should correctly parse npy files", function () {
-        const records = JSON.parse(fs.readFileSync("test/records.json"));
-        let n = new N();
+        const records = JSON.parse(await fs.readFile("test/records.json"));
+        const n = new N();
 
-        for (let fname in records) {
-            let fcontents = fs.readFile(
-                path.resolve(`test/${fname}.npy`),
-                null,
-                function (err, res) {
-                    assert.equal(err, null);
-                    let data = n.parse(res.buffer);
-                    Array.prototype.slice.call(
-                        data.data.slice(-5)
-                    ).forEach((i, j) => {
-                        assert.equal(records[fname][j], i);
-                    });
-                }
-            );
+        for (const fname in records) {
+            const fpath = path.join("test", `${fname}.npy`)
+            const data = await n.load(`http://localhost:${port}/${fpath}`)
+            Array.prototype.slice.call(
+                data.data.slice(-5)
+            ).forEach((i, j) => {
+                assert.equal(records[fname][j], i);
+            });
         }
+
+        server.close();
     });
 });


### PR DESCRIPTION
This PR makes npyjs use `Response.arrayBuffer()` if present since it's way way faster than using a FileReader in Firefox. 

From my tests with a 4.8MB file it now takes about ~448ms instead of 50 seconds.

For backwards compatibility this keeps the FileReader fallback but I don't think it's actually needed in any modern browsers. It also cleans up the error handling to actually throw errors since that's generally what people expect to happen if a file fails to load.

Test plan:

```
mocha
```