### PR TITLE
[wip] Begin npyjs.format implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ n.load("test.npy").then((res) => {
 const npyArray = await n.load("test.npy");
 ```
 
+## Format
+
+**npyjs.format** takes a [typed array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Typed_arrays) of data and an array with the dimensions of the data. It returns a [npy file](https://numpy.org/devdocs/reference/generated/numpy.lib.format.html).
+
+```js
+import fs from 'fs'
+
+const typedArray = new Int8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+const out = npyjs.format(typedArray, [5, 2])
+
+fs.writeFileSync('ints.npy', out)
+
 ## Accessing multidimensional array elements
 
 -   You can conveniently access multidimensional array elements using the 'ndarray' library:

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
 import assert from "assert";
-import {promises as fs} from "fs";
+import { promises as fs } from "fs";
 import path from "path";
 import http from "http";
 import N from "../index.js";
@@ -13,7 +13,7 @@ describe("npyjs parser", function () {
             res.end(data);
         });
         server.listen();
-        const {port} = server.address()
+        const { port } = server.address()
 
         const records = JSON.parse(await fs.readFile("test/records.json"));
         const n = new N();
@@ -26,6 +26,38 @@ describe("npyjs parser", function () {
             ).forEach((i, j) => {
                 assert.equal(records[fname][j], i);
             });
+        }
+
+        server.close();
+    });
+});
+
+
+describe("npyjs formatter", function () {
+    it("should correctly format npy files", async function () {
+        const server = http.createServer(async function (req, res) {
+            const fpath = path.resolve(req.url.slice(1));
+            const data = await fs.readFile(fpath);
+            res.writeHead(200);
+            res.end(data);
+        });
+        server.listen();
+        const { port } = server.address()
+
+        const records = JSON.parse(await fs.readFile("test/records.json"));
+        const n = new N();
+
+        for (const fname in records) {
+            console.log(fname)
+            const fpath = path.join("test", `${fname}.npy`)
+            const data = await n.load(`http://localhost:${port}/${fpath}`);
+            const formatted = new Int8Array(n.format(data.data, data.shape));
+            const fileContents = await fs.readFile(fpath);
+            let fileContentsBytes = new Int8Array(fileContents);
+            console.log(formatted.slice(0, 100))
+            console.log(fileContentsBytes.slice(0, 100))
+            assert.deepEqual(formatted, fileContentsBytes);
+
         }
 
         server.close();


### PR DESCRIPTION
Publishing a WIP as I have to step away from this for a little bit and perhaps someone will want to carry this across the finish-line :) 

This begins to add a `.format` function that converts an in-memory typed array back to a .npy-formatted bytestring.