### PR TITLE
fixed uint32 array

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ class npyjs {
             "<u4": {
                 name: "uint32",
                 size: 32,
-                arrayConstructor: Int32Array,
+                arrayConstructor: Uint32Array,
             },
             "<i4": {
                 name: "int32",


### PR DESCRIPTION
The constructor being int32 causes bug for arrays with values bigger than 2^31 in uint32 type arrays, making these values negative for a unsigned type.