### PR TITLE
Draft: Added dump function to allow to write back arrays on files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,19 @@ export type DType =
     | "i1" | "u1" | "i2" | "u2" | "i4" | "u4" | "i8" | "u8"
     | "f2" | "f4" | "f8" | "b1";
 
+export type TypedArray =
+    | Int8Array
+    | Int16Array
+    | Int32Array
+    | BigInt64Array
+    | Uint8Array
+    | Uint8ClampedArray
+    | Uint16Array
+    | Uint32Array
+    | BigUint64Array
+    | Float32Array
+    | Float64Array;
+
 export interface NpyArray<T extends ArrayBufferView = ArrayBufferView> {
     data: T;
     shape: number[];
@@ -117,6 +130,79 @@ export async function load(source: string | ArrayBuffer | ArrayBufferView, opts:
 // keep existing named exports above (load, types, etc.)
 export function float16ToFloat32(u16: number): number {
     return f16toF32(u16);
+}
+
+function arrayToDtype(array: unknown): DType {
+    if (array instanceof Uint8Array) {
+        return "u1";
+    }
+    if (array instanceof Uint8ClampedArray) {
+        return "u1";
+    }
+    if (array instanceof Int8Array) {
+        return "i1";
+    }
+    if (array instanceof Uint16Array) {
+        return "u2";
+    }
+    if (array instanceof Int16Array) {
+        return "i2";
+    }
+    if (array instanceof Uint32Array) {
+        return "u4";
+    }
+    if (array instanceof Int32Array) {
+        return "i4";
+    }
+    if (array instanceof Float32Array) {
+        return "f4";
+    }
+    if (array instanceof BigUint64Array) {
+        return "u8";
+    }
+    if (array instanceof BigInt64Array) {
+        return "i8";
+    }
+    if (array instanceof Float64Array) {
+        return "f8";
+    }
+    const kind = typeof array === "object" ? array?.constructor?.name : typeof array;
+    throw new TypeError(`Unsupported dtype for ${kind}`);
+}
+
+/**
+ * True if the system is little endian.
+ */
+function isLittleEndian(): boolean {
+    // The result could be cached
+    return ((new Uint32Array((new Uint8Array([1, 0, 0, 0])).buffer))[0] === 1);
+}
+
+export function dump(array: TypedArray, shape: number[]) {
+    function createPyDescription() {
+        const dtype = arrayToDtype(array);
+        const isByte = dtype == 'u1' || dtype == 'i1';
+        const endianness = isByte ? '|' : (isLittleEndian() ? '<' : '>');
+        const descr = `${endianness}${dtype}`;
+        const pyShape = shape.map((v) => { return `${v}`; }).join(",");
+        return `{'descr':'${descr}','fortran_order':False,'shape':(${pyShape})}`;
+    }
+    let pyDesc = createPyDescription();
+    let headerSize = 10 + pyDesc.length;
+    const pad = 8 - ((headerSize + 1) % 8);
+    pyDesc = pyDesc + " ".repeat(pad) + "\x0A";
+    headerSize += pad + 1;
+    const buffer = new ArrayBuffer(headerSize + array.byteLength);
+    const view = new DataView(buffer);
+    view.setUint32(0, 2471384397, false);
+    view.setUint32(4, 1348010240, false);
+    view.setUint16(8, pyDesc.length, true);
+    const encoder = new TextEncoder();
+    const header = new Uint8Array(buffer, 10, pyDesc.length);
+    encoder.encodeInto(pyDesc, header);
+    const data = new Uint8Array(buffer, 10 + pyDesc.length);
+    data.set(new Uint8Array(array.buffer, array.byteOffset, array.byteLength));
+    return buffer;
 }
 
 // Back-compat class API (matches old tests)

--- a/test/dump.test.ts
+++ b/test/dump.test.ts
@@ -1,0 +1,49 @@
+// tests/dump.test.ts
+import { describe, it, expect } from "vitest";
+import * as npyjs from "../src";
+
+describe("npyjs dump", () => {
+
+    it("each kind", async () => {
+        const arrays = [
+            new Uint8Array([1, 2, 254, 255]),
+            new Int8Array([1, 2, 254, 255]),
+            new Uint8ClampedArray([1, 2, 254, 255]),
+            new Uint16Array([1, 2, 254, 255]),
+            new Int16Array([1, 2, 999, 1000]),
+            new Uint32Array([1, 2, 999, 1000]),
+            new Int32Array([1, 2, 999, 1000]),
+            new Float32Array([0.1, NaN, 10_000, Infinity]),
+            new BigUint64Array([BigInt(1), BigInt(1), BigInt(1), BigInt(1_000_000_000_000_000)]),
+            new BigInt64Array([BigInt(1), BigInt(1), BigInt(1), BigInt(1_000_000_000_000_000)]),
+            new Float64Array([0.1, NaN, 10_000, Infinity]),
+        ];
+        for (let array of arrays) {
+            const bytes = npyjs.dump(array, [2, 2]);
+            const expected = array  instanceof Uint8ClampedArray ? new Uint8Array(array.buffer) : array;
+            // parse back the bytes to check the result
+            const result = await npyjs.load(bytes);
+            expect(result.shape).toEqual([2, 2]);
+            expect(result.data).toEqual(expected);
+        }
+    });
+
+    it("check width/height", async () => {
+        const array = new Uint8Array([1, 2, 3, 4, 5, 6]);
+        const shape = [3, 2];
+        const bytes = npyjs.dump(array, shape);
+        const result = await npyjs.load(bytes);
+        expect(result.shape).toEqual(shape);
+    });
+
+    it("unsupported array", async () => {
+        class MyArray {};
+        const array = new MyArray();
+        try {
+            // @ts-expect-error
+            npyjs.dump(array);
+        } catch (error) {
+            expect(error.toString()).toContain("MyArray")
+        }
+    });
+});


### PR DESCRIPTION
Hi,

Here is an implementation to create `npy` binary data from a `TypedArray`.

It was rebased on top of #52. This closes #53.

It can be used the following way:

```
import * as fs from 'fs';
import * as npyjs from 'npyjs';

const myarray = new Uint8Array([1, 2, 3, 4});
const shape = [2, 2];
const bytes = npyjs.dump(myarray, shape);
fs.writeFileSync('myarray.npy', new Uint8Array(bytes));
```

Notice that i have added the function `isLittleEndian()` to check the endianness of the system. This can also be used while loading an array for safety.