### PR TITLE
Fix module and export paths in package.json, update lock file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "npyjs",
-    "version": "1.0.0",
+    "version": "1.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "npyjs",
-            "version": "1.0.0",
+            "version": "1.0.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "cross-fetch": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "bugs": "https://github.com/aplbrain/npyjs/issues",
     "type": "module",
     "main": "./dist/index.cjs",
-    "module": "./dist/index.mjs",
+    "module": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "files": [
         "dist"
@@ -17,12 +17,12 @@
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
-            "import": "./dist/index.mjs",
+            "import": "./dist/index.js",
             "require": "./dist/index.cjs"
         },
         "./reshape": {
             "types": "./dist/reshape.d.ts",
-            "import": "./dist/reshape.mjs",
+            "import": "./dist/reshape.js",
             "require": "./dist/reshape.cjs"
         }
     },


### PR DESCRIPTION
Actual files in `/dist` folder can be seen e.g. by:
- Running `npm run build`
- Visiting https://app.unpkg.com/npyjs@1.0.2/files/dist

Fix outdated version entry in `package-lock.json`:
- The lock file should usually be updated automatically when setting the new version using the npm CLI, e.g. for a new patch version 1.0.3, run `npm version patch`  
  See https://docs.npmjs.com/cli/v8/commands/npm-version#description

Fixes #59